### PR TITLE
Fix timeout during 10-adduser

### DIFF
--- a/docker-s6/Dockerfile
+++ b/docker-s6/Dockerfile
@@ -74,5 +74,8 @@ RUN head -1 /etc/cont-init.d/* /etc/services.d/trafegodns/*
 # Configure volumes
 VOLUME /config
 
+# Avoid timeout errors adjusting permissions during first run
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 0
+
 # Set entrypoint to s6-overlay init
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
Fixes #255 

Symptom on first container startup:

```
Setting permissions on app and config directories
s6-rc: fatal: timed out
s6-sudoc: fatal: unable to get exit status from server: Operation timed out
```

Inspired by: https://github.com/pi-hole/docker-pi-hole/pull/1192/files