### PR TITLE
Read secrets from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A service that automatically manages DNS records based on container configuratio
 - [Logging System](#logging-system)
 - [Performance Optimisation](#performance-optimisation)
 - [Automatic Apex Domain Handling](#automatic-apex-domain-handling)
+- [Using Docker Secrets](#using-docker-secrets)
 - [Building from Source](#building-from-source)
 - [Development](#development)
 - [Licence](#licence)
@@ -810,6 +811,41 @@ The application includes robust timeout handling for API operations:
 ## Automatic Apex Domain Handling
 
 The DNS Manager automatically detects apex domains (e.g., `example.com`) and uses A records with your public IP instead of CNAME records, which are not allowed at the apex domain level.
+
+## Using Docker Secrets
+
+Any environment variables supported by TrafegoDNS that contain secrets, i.e. those ending in `_TOKEN`, `_KEY` or `_PASSWORD` support receiving the secret vie Docker [secrets](https://docs.docker.com/compose/how-tos/use-secrets/). 
+
+To provide a value via secret file, append the suffix `_FILE` to the variable name and specify the path to the file that contains the secret.
+
+Example:
+
+```
+secrets:
+  cloudflare_dns_api_token:
+    file: ${APPDATA_LOCATION:-/srv/appdata}/secrets/cloudflare_dns_api_token
+
+services:
+  trafego:
+    container_name: trafego
+    image: eafxx/traefik-dns-manager:latest
+    restart: unless-stopped
+    volumes: 
+      - trafego:/config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    secrets:
+      - cloudflare_dns_api_token
+    environment:
+      CLOUDFLARE_TOKEN_FILE: /run/secrets/cloudflare_dns_api_token
+```
+
+### Supported Secret Variables
+
+- CLOUDFLARE_TOKEN_FILE
+- ROUTE53_ACCESS_KEY_FILE
+- ROUTE53_SECRET_KEY_FILE
+- DO_TOKEN_FILE
+- TRAEFIK_API_PASSWORD_FILE
 
 ## Building from Source
 

--- a/src/config/ConfigManager.js
+++ b/src/config/ConfigManager.js
@@ -28,18 +28,18 @@ class ConfigManager {
     
     // Provider-specific settings
     // Cloudflare settings
-    this.cloudflareToken = EnvironmentLoader.getString('CLOUDFLARE_TOKEN');
+    this.cloudflareToken = EnvironmentLoader.getSecret('CLOUDFLARE_TOKEN');
     this.cloudflareZone = EnvironmentLoader.getString('CLOUDFLARE_ZONE');
     
     // Route53 settings
-    this.route53AccessKey = EnvironmentLoader.getString('ROUTE53_ACCESS_KEY');
-    this.route53SecretKey = EnvironmentLoader.getString('ROUTE53_SECRET_KEY');
+    this.route53AccessKey = EnvironmentLoader.getSecret('ROUTE53_ACCESS_KEY');
+    this.route53SecretKey = EnvironmentLoader.getSecret('ROUTE53_SECRET_KEY');
     this.route53Zone = EnvironmentLoader.getString('ROUTE53_ZONE');
     this.route53ZoneId = EnvironmentLoader.getString('ROUTE53_ZONE_ID');
     this.route53Region = EnvironmentLoader.getString('ROUTE53_REGION', 'eu-west-2');
     
     // Digital Ocean settings
-    this.digitalOceanToken = EnvironmentLoader.getString('DO_TOKEN');
+    this.digitalOceanToken = EnvironmentLoader.getSecret('DO_TOKEN');
     this.digitalOceanDomain = EnvironmentLoader.getString('DO_DOMAIN');
     
     // Validate required settings based on provider
@@ -48,7 +48,7 @@ class ConfigManager {
     // Traefik API settings
     this.traefikApiUrl = EnvironmentLoader.getString('TRAEFIK_API_URL', 'http://traefik:8080/api');
     this.traefikApiUsername = EnvironmentLoader.getString('TRAEFIK_API_USERNAME');
-    this.traefikApiPassword = EnvironmentLoader.getString('TRAEFIK_API_PASSWORD');
+    this.traefikApiPassword = EnvironmentLoader.getSecret('TRAEFIK_API_PASSWORD');
     
     // Label prefixes
     this.genericLabelPrefix = EnvironmentLoader.getString('DNS_LABEL_PREFIX', 'dns.');

--- a/src/config/EnvironmentLoader.js
+++ b/src/config/EnvironmentLoader.js
@@ -36,6 +36,33 @@ class EnvironmentLoader {
     }
     
     /**
+     * Get environment variable as a secret
+     * Checks if <name>_FILE is defined and reads the contents from the file
+     * @param {string} name - Environment variable name
+     * @param {string} defaultValue - Default value if not set
+     * @returns {string} The secret value or default value
+     */
+    static getSecret(name, defaultValue = '') {
+      const fileVarName = `${name}_FILE`;
+      const filePath = process.env[fileVarName];
+
+      if (filePath) {
+        try {
+          const fs = require('fs');
+          if (fs.existsSync(filePath)) {
+            return fs.readFileSync(filePath, 'utf8').trim();
+          } else {
+            throw new Error(`Secret file not found at path: ${filePath}`);
+          }
+        } catch (error) {
+          throw new Error(`Error reading secret file for ${name}: ${error.message}`);
+        }
+      }
+
+      return this.get(name, defaultValue);
+    }
+    
+    /**
      * Get environment variable as integer
      */
     static getInt(name, defaultValue = 0) {


### PR DESCRIPTION
Fixes #251 

This change makes it possible to provide the following variables as secret files:

- CLOUDFLARE_TOKEN_FILE
- ROUTE53_ACCESS_KEY_FILE
- ROUTE53_SECRET_KEY_FILE
- DO_TOKEN_FILE
- TRAEFIK_API_PASSWORD_FILE

Example:

```diff
+ secrets:
+   cloudflare_dns_api_token:
+     file: ${APPDATA_LOCATION}/secrets/cloudflare_dns_api_token
  
  services:
    trafego:
      container_name: trafego
      image: avargaskun/trafegodns:latest
      restart: unless-stopped
      volumes: 
        - trafego:/config
        - /var/run/docker.sock:/var/run/docker.sock:ro
+     secrets:
+       - cloudflare_dns_api_token
      environment:
-       CLOUDFLARE_TOKEN: ${CF_DNS_API_TOKEN}
+       CLOUDFLARE_TOKEN_FILE: /run/secrets/cloudflare_dns_api_token
```